### PR TITLE
Fix typo in .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-msh
+mysh
 toy
 *.o
 *.dSYM


### PR DESCRIPTION
Given Makefile build `mysh` `toy` binary; thus, `msh` seems to be `mysh`